### PR TITLE
Fix build to include the correct README

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -53,7 +53,7 @@ build_triplet = @build@
 host_triplet = @host@
 bin_PROGRAMS = SteamCAD$(EXEEXT)
 subdir = .
-DIST_COMMON = README $(am__configure_deps) $(srcdir)/Makefile.am \
+DIST_COMMON = README.md $(am__configure_deps) $(srcdir)/Makefile.am \
 	$(srcdir)/Makefile.in $(top_srcdir)/Linux/config.h.in \
 	$(top_srcdir)/configure ABOUT-NLS AUTHORS COPYING ChangeLog \
 	INSTALL NEWS compile config.guess config.rpath config.sub \


### PR DESCRIPTION
New source builds [like this one](https://github.com/oskardolch/SteamCAD/archive/continuous.zip) include an *empty* file called `README` in addition to what seems to be the intended `README.md`.

This was introduced in https://github.com/oskardolch/SteamCAD/commit/57d9057b1757bc05d1d15b88db51b3ec4744e0ba